### PR TITLE
Added parameter "apply_gradients" to disable parameter update step.

### DIFF
--- a/torch_kfac/kfac_optimizer.py
+++ b/torch_kfac/kfac_optimizer.py
@@ -28,7 +28,8 @@ class KFAC(object):
                  l2_reg: float = 0.,
 
                  update_cov_manually: bool = False,
-                 center: bool = False) -> None:
+                 center: bool = False,
+                 apply_gradients: bool = True) -> None:
         """Creates the KFAC Optimizer object.
 
         Args:
@@ -58,6 +59,9 @@ class KFAC(object):
                 or when you want your covariances w.r.t. the model distribution rather than the loss function. Defaults to False.
             center (bool, optional): If set to True the activations and sensitivities are centered. This is useful when dealing with
                 unnormalized distributions. Defaults to False.
+            apply_gradients (bool, optional): If set to True, the gradients will be applied to the parameters according
+                to gradient descent and no further optimizer needs to be applied to the model. If set to false, you can
+                use your own first order optimizer (like Adam) to apply the gradients to the model parameters.
         """
 
         legal_momentum_types = ['regular', 'adam']
@@ -84,6 +88,7 @@ class KFAC(object):
         self._prev_loss = torch.tensor(np.nan, device=device, dtype=dtype)
         self._rho = torch.tensor(np.nan, device=device, dtype=dtype)
         self._min_damping = min_damping
+        self._apply_gradients = apply_gradients
 
         self._weight_decay = weight_decay
         self._l2_reg = l2_reg
@@ -307,11 +312,11 @@ class KFAC(object):
         for precon_grad, layer in raw_updates_and_layers:
             layer.set_gradients(precon_grad)
 
-        # Do gradient step - if any parameter gradient was not updated by its natural gradient
-        # this will fall back to the normal gradient.
-        for param in self.model.parameters():
-            if param.grad is not None:
-                param.add_(param.grad, alpha=-self.learning_rate)
+        if self._apply_gradients:
+            # Do gradient step: apply gradients to parameters according to gradient descent.
+            for param in self.model.parameters():
+                if param.grad is not None:
+                    param.add_(param.grad, alpha=-self.learning_rate)
 
         # Cache previous loss
         if loss is not None:


### PR DESCRIPTION
If you want to use the preconditioning only and use another first order optimizer like Adam, you need to disable the parameter updates in the "step" function. I added the parameter "apply_gradients", which can be set to False to avoid the parameter updates.

The new training loop would look like this:
```python
kfac = torch_kfac.KFAC(model, learning_rate=1e-3, damping=1e-3,damping_adaptation_decay=0, momentum=0, apply_gradients=False)
optimizer = torch.optim.Adam(model.parameters(), lr=0.01, weight_decay=0.005)
...
model.zero_grad()
with kfac.track_forward():
  # forward pass
  loss = ...
with kfac.track_backward():
  # backward pass
  loss.backward()
kfac.step()
optimizer.step()
```
I don't know if this is actually necessary, because I could also set the learning rate to 0. What do you think?
Thanks a lot for the work on this library.