### PR TITLE
Added parameter "enable_pi_correction" to control if Tikhonov pi correction is used

### DIFF
--- a/tests/layers/test_fisher_block.py
+++ b/tests/layers/test_fisher_block.py
@@ -1,0 +1,54 @@
+import unittest
+from math import sqrt
+
+from torch import float64, tensor, device
+
+from torch_kfac.layers import FisherBlock
+from torch_kfac.utils import Lock
+
+
+class FisherBlockTest(unittest.TestCase):
+
+    # activations covariance matrix
+    act_cov = tensor([[1, 2, 3], [2, 5, 6], [3, 6, 9]], dtype=float64) / 10
+    # sensitivities covariance matrix
+    sen_cov = tensor([[4, 5, 6], [5, 8, 9], [6, 9, 12]], dtype=float64) / 10
+
+    def get_test_block(self) -> FisherBlock:
+        block = FisherBlock(3, 3, dtype=float64, device=device("cpu"))
+        block._activations_cov.add_to_average(self.act_cov, decay=0)
+        block._sensitivities_cov.add_to_average(self.sen_cov, decay=0)
+        return block
+
+    def test_calculate_damping_with_pi_correction(self):
+        """
+        Tests calculation of damping if Tikhonov pi correction is enabled.
+        """
+        block = self.get_test_block()
+        block.setup(Lock(), Lock(), True)
+        damping = 1e-1
+        a_damp, s_damp = block.compute_damping(tensor(damping), block.renorm_coeff)
+
+        denominator = (4 + 8 + 12) / 10 * 3
+        numerator = (1 + 5 + 9) / 10 * 3
+        pi = sqrt(numerator / denominator)
+        expected_a_damp = damping ** 0.5 * pi
+        expected_s_damp = damping ** 0.5 / pi
+        self.assertAlmostEqual(expected_a_damp, a_damp.item())
+        self.assertAlmostEqual(expected_s_damp, s_damp.item())
+
+    def test_calculate_damping_no_pi_correction(self):
+        """
+        Tests calculation of damping if Tikhonov pi correction is disabled.
+        """
+        block = self.get_test_block()
+        block.setup(Lock(), Lock(), False)
+        damping = 1e-1
+        a_damp, s_damp = block.compute_damping(tensor(damping), block.renorm_coeff)
+        expected_damp = damping ** 0.5
+        self.assertAlmostEqual(expected_damp, a_damp.item())
+        self.assertAlmostEqual(expected_damp, s_damp.item())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_kfac_optimizer.py
+++ b/tests/test_kfac_optimizer.py
@@ -1,0 +1,21 @@
+import unittest
+
+from torch import tensor
+from torch.nn import Linear
+
+from torch_kfac import KFAC
+
+
+class KfacOptimizerTest(unittest.TestCase):
+    def test_disable_pi_correction(self):
+        """
+        Checks if the enable_pi_correction parameter is correctly copied to the Fisher blocks.
+        """
+        model = Linear(3, 4)
+        preconditioner = KFAC(model, 0.01, tensor(1e-2), enable_pi_correction=False)
+        self.assertEqual(1, len(preconditioner.blocks))
+        self.assertFalse(preconditioner.blocks[0]._enable_pi_correction)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/torch_kfac/kfac_optimizer.py
+++ b/torch_kfac/kfac_optimizer.py
@@ -28,7 +28,8 @@ class KFAC(object):
                  l2_reg: float = 0.,
 
                  update_cov_manually: bool = False,
-                 center: bool = False) -> None:
+                 center: bool = False,
+                 enable_pi_correction: bool = True) -> None:
         """Creates the KFAC Optimizer object.
 
         Args:
@@ -58,6 +59,8 @@ class KFAC(object):
                 or when you want your covariances w.r.t. the model distribution rather than the loss function. Defaults to False.
             center (bool, optional): If set to True the activations and sensitivities are centered. This is useful when dealing with
                 unnormalized distributions. Defaults to False.
+            enable_pi_correction (bool, optional): If set to true, the pi-correction for the Tikhonov regularization
+                will be calculated.
         """
 
         legal_momentum_types = ['regular', 'adam']
@@ -101,6 +104,7 @@ class KFAC(object):
                 init_fisher_block(
                     module,
                     center=center,
+                    enable_pi_correction=enable_pi_correction,
                     forward_lock=self.track_forward,
                     backward_lock=self.track_backward
                 )


### PR DESCRIPTION
I compare this implementation to another one which does not use Tikhonov pi correction, therefore it would be great to have an extra parameter to disable it.